### PR TITLE
Add `Full-API-Dump.json` info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ https://github.com/MaximumADHD/RCT-Source
 ## API-Dump.json
 This is a JSON version of Roblox's API Dump. It contains more data than the original API Dump and can be read into a data tree by most programming languages using a JSON parser. This file is extracted using:<br/>`RobloxStudioBeta.exe -API API-Dump.json`
 
+## Full-API-Dump.json
+This is a more *"complete"* version of the normal JSON API Dump. It includes all classes and enums omitted from the normal dump, and includes a few other notable differences and keys, like `Default` values on some properties. This file can be extracted with, similarly to `-API`:<br/>`RobloxStudioBeta.exe -FullAPI Full-API-Dump.json`
+
 ## API-Dump.txt
 A readable version of Roblox's JSON API Dump. This file is generated from the [Roblox API Dump Tool](https://github.com/MaximumADHD/Roblox-API-Dump-Tool).
 


### PR DESCRIPTION
As [recently discovered and documented](https://github.com/MaximumADHD/Roblox-API-Dump-Tool/commit/129df6a2f695013f7efcc75c33c62f6fd13d7582), adding this info to the README for documentation sake.

I pushed out a very simple script to demo this all aswell: <https://github.com/regginator/parse-full-api-dump>